### PR TITLE
Update for PureScript 0.15

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,12 +12,12 @@
     "output"
   ],
   "dependencies": {
-    "purescript-aff": "^5.1.1",
-    "purescript-node-child-process": "^6.0.0",
-    "purescript-effect": "^2.0.1",
-    "purescript-prelude": "^4.1.1"
+    "purescript-aff": "^7.0.9",
+    "purescript-node-child-process": "^9.0.0",
+    "purescript-effect": "^4.0.0",
+    "purescript-prelude": "^6.0.0"
   },
   "devDependencies": {
-    "purescript-test-unit": "^15.0.0"
+    "purescript-test-unit": "^17.0.0"
   }
 }

--- a/src/Sunde.purs
+++ b/src/Sunde.purs
@@ -41,8 +41,8 @@ spawn' encoding killSignal {cmd, args, stdin} options = makeAff \cb -> do
   case stdin of
     Just input -> do
       let write = CP.stdin process
-      void $ NS.writeString write UTF8 input do
-        NS.end write mempty
+      void $ NS.writeString write UTF8 input \_ -> do
+        NS.end write (\_ -> mempty)
     Nothing -> pure unit
 
   onDataString (CP.stdout process) encoding \string ->


### PR DESCRIPTION
This PR updates `sunde` for compatibility with the latest versions of its dependencies, namely the `node-child-process` library which has had changes to the `writeString` and `end` functions used here (they now accept an optional error in their callback).